### PR TITLE
ft(show ideas): style page to show ideas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,3 @@ typings/
 dist/
 bundle.js
 .DS_STORE
-client/components/CreateIdea.jsx
-client/containers/CategoryPage.jsx
-client/containers/IdeasPage.jsx

--- a/client/containers/CategoryPage.jsx
+++ b/client/containers/CategoryPage.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { compiler } from 'markdown-to-jsx';
 import { Link } from 'react-router-dom';
 import ReactPaginate from 'react-paginate';
 import SideNav from '../containers/SideNav';
@@ -133,18 +134,40 @@ class CategoryPage extends Component {
             <ul>
               { this.state.categoryIdeas.length > 0 ? this.state.categoryIdeas.map(ideas => (
                 <li className="col s12 m6 l4" key={ideas._id}>
-                  <div className="card white">
+                  <div className="card sticky-action medium white">
                     <div className="card-content black-text">
-                      <span className="card-title">{ideas.title}</span>
-                      <div>{ideas.description}</div>
+                      <span className="card-title activator grey-text text-darken-4">{ideas.title}
+                        <i className="material-icons right">more_vert</i>
+                      </span>
                       <br />
                       <p className="black-text">
                         <strong>Category:</strong>
                         <span className="new badge" data-badge-caption="">{ideas.categories}</span>
                       </p>
+                      <hr />
+                      <div className="truncate">{typeof ideas.description === 'string' ? compiler(ideas.description) : ''}</div>
+                    </div>
+                    <div className="card-reveal black-text">
+                      <span className="card-title grey-text text-darken-4">
+                      Card Title<i className="material-icons right">close</i>
+                      </span>
+                      <div>{typeof ideas.description === 'string' ? compiler(ideas.description) : ''}</div>
                     </div>
                     <div className="card-action">
                       <Link to={`/idea/id/${ideas._id}`}><i className="material-icons">comment</i> Comment</Link>
+                      <a
+                        href={`https://twitter.com/intent/tweet?text=This%20is%20amazing%20you%20should%20read%20it&url=${window.location.origin}/idea/${ideas._id}`}
+                        className="tooltipped center"
+                        data-position="bottom"
+                        data-delay="50"
+                        data-tooltip="Like this? share on twitter"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <i className="material-icons">
+                          share
+                        </i>
+                      </a>
                       {ideas.modified ? edited : ''}
                     </div>
                   </div>

--- a/client/containers/GetPublicIdeas.jsx
+++ b/client/containers/GetPublicIdeas.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
+import { compiler } from 'markdown-to-jsx';
 import ReactPaginate from 'react-paginate';
 import { getPublicIdeas } from '../actions';
 
@@ -106,22 +107,47 @@ class GetPublicIdeas extends Component {
       <div>
         <div className="row show-ideas">
           <ul>
-            { this.state.publicIdeas.map(ideas => (
+            { this.state.publicIdeas.length > 0 ? this.state.publicIdeas.map(ideas => (
               <li className="col s12 m6 l4" key={ideas._id}>
-                <div className="card medium white">
-                  <div className="card-content black-text">
-                    <span className="card-title">{ideas.title}</span>
-                    <p>{ideas.description}</p>
+                <div className="card sticky-action medium white">
+                  <div className="card-content black-text ">
+                    <span className="card-title activator grey-text text-darken-4">{ideas.title}
+                      <i className="material-icons right">more_vert</i>
+                    </span>
                     <br />
-                    <p className="black-text"><strong>Category:</strong> <span className="new badge" data-badge-caption="">{ideas.categories}</span></p>
+                    <p className="black-text">
+                      <strong>Category:</strong>
+                      <span className="new badge" data-badge-caption="">{ideas.categories}</span>
+                    </p>
+                    <hr />
+                    <div className="truncate">{typeof ideas.description === 'string' ? compiler(ideas.description) : ''}</div>
+                  </div>
+                  <div className="card-reveal black-text">
+                    <span className="card-title grey-text text-darken-4">
+                    Card Title<i className="material-icons right">close</i>
+                    </span>
+                    <div>{typeof ideas.description === 'string' ? compiler(ideas.description) : ''}</div>
                   </div>
                   <div className="card-action">
                     <Link to={`/idea/id/${ideas._id}`}><i className="material-icons">comment</i>Comment</Link>
+                    <a
+                      href={`https://twitter.com/intent/tweet?text=This%20is%20amazing%20you%20should%20read%20it&url=${window.location.origin}/idea/${ideas._id}`}
+                      className="tooltipped center"
+                      data-position="bottom"
+                      data-delay="50"
+                      data-tooltip="Like this? share on twitter"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <i className="material-icons">
+                        share
+                      </i>
+                    </a>
                     {ideas.modified ? edited : ''}
                   </div>
                 </div>
               </li>
-            ))}
+            )) : (<h3> There are no ideas for this category</h3>)}
           </ul>
         </div>
         <ReactPaginate

--- a/client/containers/SideNav.jsx
+++ b/client/containers/SideNav.jsx
@@ -215,10 +215,22 @@ export class SideNav extends Component {
   }
 }
 
-SideNav.propTypes = {
-  logout: PropTypes.func.isRequired,
-  getByCategory: PropTypes.func.isRequired,
-  category: PropTypes.string.isRequired
+const sideNavPropTypes = () => {
+  const sideNav = new SideNav();
+  if (sideNav.props.category) {
+    return {
+      logout: PropTypes.func.isRequired,
+      getByCategory: PropTypes.func.isRequired,
+      category: PropTypes.string.isRequired
+    };
+  }
+  return {
+    getByCategory: PropTypes.func.isRequired,
+    category: PropTypes.string.isRequired
+  };
 };
+
+
+SideNav.propTypes = sideNavPropTypes;
 
 export default connect(null, { logout, getByCategory })(SideNav);

--- a/client/containers/UserIdeaPage.jsx
+++ b/client/containers/UserIdeaPage.jsx
@@ -181,15 +181,19 @@ class UserIdeaPage extends Component {
                         <strong>Status:</strong>
                         <span className="black-text edited">{ideas.status}</span>
                       </p>
+                      <hr />
+                      <div className="truncate">{typeof ideas.description === 'string' ? compiler(ideas.description) : ''}</div>
                     </div>
-                    <div className="card-reveal">
-                      <div>{compiler(ideas.description)}</div>
-                      <span className="card-title grey-text text-darken-4">Card Title<i className="material-icons right">close</i></span>
+                    <div className="card-reveal black-text">
+                      <span className="card-title grey-text text-darken-4">
+                      Card Title<i className="material-icons right">close</i>
+                      </span>
+                      <div>{typeof ideas.description === 'string' ? compiler(ideas.description) : ''}</div>
                     </div>
                     <div className="card-action">
                       <Link to={`/idea/edit/${ideas._id}`}><i className="material-icons">edit</i></Link>
                       <a
-                        href={`https://twitter.com/intent/tweet?text=This%20is%20amazing%20you%20should%20read%20it&url=${window.location.origin}/ideas/view/${ideas._id}`}
+                        href={`https://twitter.com/intent/tweet?text=This%20is%20amazing%20you%20should%20read%20it&url=${window.location.origin}/idea/${ideas._id}`}
                         className="tooltipped center"
                         data-position="bottom"
                         data-delay="50"
@@ -244,3 +248,4 @@ export default connect(mapStateToProps, {
   getUserIdeas,
   deleteIdea
 })(UserIdeaPage);
+


### PR DESCRIPTION
#### What does this PR do?

- Fetches Ideas from the database and displays them on the front end

#### Description of Task to be completed?


- add routes to show pubkIdeas

- add routes to show Ideas by categories

- implement frontend style to display ideas

- paginate all Ideas

- fetch Ideas by Categories

- fetch ideas belonging to logged in user

- fetch all public Ideas

#### How should this be manually tested?

- Through the app url in the Readme

#### Any background context you want to provide?

- none

#### What are the relevant pivotal tracker stories?

- https://www.pivotaltracker.com/story/show/153688454

#### Screenshots (if appropriate)

- 
<img width="1276" alt="screen shot 2017-12-15 at 1 03 35 am" src="https://user-images.githubusercontent.com/26982204/34020317-ddbf4236-e133-11e7-8d9e-ec02fe63cd98.png">



#### Questions:

- none

(finishes #153474663)

- add routes to show pubkIdeas

- add routes to show Ideas by categories

- implement frontend style to display ideas